### PR TITLE
Fix agent hang on MIPS/MIPSEL (Skip UPX)

### DIFF
--- a/beszel-agent/Makefile
+++ b/beszel-agent/Makefile
@@ -33,7 +33,11 @@ endef
 
 define Build/Compile
 	if command -v upx >/dev/null 2>&1; then \
-		upx --best --lzma $(PKG_BUILD_DIR)/beszel-agent || true; \
+		if [ "$(BESZEL_GOARCH)" = "mips" ] || [ "$(BESZEL_GOARCH)" = "mipsle" ]; then \
+			echo "Skipping UPX compression for MIPS architectures (prevents execution hang)..."; \
+		else \
+			upx --best --lzma $(PKG_BUILD_DIR)/beszel-agent || true; \
+		fi; \
 	fi
 endef
 


### PR DESCRIPTION
This PR fixes issue #9, where the agent hangs on startup and maxes out the CPU on MIPS routers (like the MT7621).

The root cause is that UPX compression breaks Go binaries on MIPS architectures during the self-extraction phase. I updated the OpenWrt Makefile to conditionally skip UPX compression specifically for mips and mipsle targets (BESZEL_GOARCH). All other architectures will continue to compress normally to save space.

### Testing:
Tested the uncompressed binary on OpenWrt 25.12 (MT7621). The agent now starts instantly and runs perfectly.